### PR TITLE
No invalid rules in ACLs

### DIFF
--- a/_test/acl.test.php
+++ b/_test/acl.test.php
@@ -28,6 +28,8 @@ class helper_plugin_aclplusregex_test extends DokuWikiTest
                 'user_name',
                 [
                     '987654_matching',
+                    'non-matching-group',
+                    '123456_matching',
                 ],
                 [
                     'customers:$1:*	@(\d{6})_.*	4',
@@ -35,7 +37,9 @@ class helper_plugin_aclplusregex_test extends DokuWikiTest
                 ],
                 [
                     'customers:987654:*	user%5fname	4',
+                    'customers:123456:*	user%5fname	4',
                     'customers:987654:secret:*	user%5fname	0',
+                    'customers:123456:secret:*	user%5fname	0',
                 ],
             ],
             [


### PR DESCRIPTION
Restore a validity check before adding a rule to ACLs. Previous commit removed the check and as a result some provisional, nonsensical rules were inserted.