### PR TITLE
Allow regular expressions in the id/namespace part of ACL config

### DIFF
--- a/_test/acl.test.php
+++ b/_test/acl.test.php
@@ -85,6 +85,72 @@ class helper_plugin_aclplusregex_test extends DokuWikiTest
     }
 
     /**
+     * @return array
+     * @see testFullChainNsRegex
+     */
+    public function providerFullChainNsRegex()
+    {
+        return [
+            [
+                'reg:12345:678:sub',
+                'joshua',
+                ['foo', '12345-doku-sub-r1'],
+                4,
+            ],
+            [
+                'reg:12345:sub-678:sub',
+                'joshua',
+                ['foo', '12345-doku-bus-sub-r2'],
+                16,
+            ],
+            [
+                'reg:12345:sub-678:bus',
+                'joshua',
+                ['foo', '12345-doku-bus-sub-r2'],
+                2,
+            ],
+            [
+                'reg:12345:sub-90:sub',
+                'joshua',
+                ['foo', '12345-doku-bus-sub-r3'],
+                8,
+            ],
+            [
+                'reg:12345:sub-90:bus',
+                'joshua',
+                ['foo', '12345-doku-bus-sub-r3'],
+                1,
+            ],
+        ];
+    }
+
+    /**
+     * Run a full check on the result our system should deliver for the given names
+     *
+     * Testing happens against _test/conf/aclplusregex.conf
+     *
+     * @dataProvider providerFullChainNsRegex
+     * @param string $id
+     * @param string $user
+     * @param string[] $groups
+     * @param int|false $expected
+     */
+    public function testFullChainNsRegex($id, $user, $groups, $expected)
+    {
+        $act = new TestAction();
+
+        $this->assertSame(
+            $expected,
+            $act->evaluateRegex(
+                $act->rulesToRegex(
+                    $act->loadACLRules($user, $groups)
+                ),
+                $id
+            )
+        );
+    }
+
+    /**
      * @return array (entities, id, pattern, expected)
      * @see testGetIdPatterns
      */

--- a/_test/acl.test.php
+++ b/_test/acl.test.php
@@ -316,6 +316,18 @@ class helper_plugin_aclplusregex_test extends DokuWikiTest
                     'zz' => 1,
                 ],
             ],
+            [
+                [
+                    'reg:12345:(sub-\d{3}):sub' => 1,
+                    'reg:12345:(sub-\d{3}):*' => 1,
+                    'reg:12345:sub-678:bus' => 1,
+                ],
+                [
+                    'reg:12345:sub-678:bus' => 1,
+                    'reg:12345:(sub-\d{3}):sub' => 1,
+                    'reg:12345:(sub-\d{3}):*' => 1,
+                ],
+            ],
         ];
     }
 

--- a/_test/conf/aclplusregex.conf
+++ b/_test/conf/aclplusregex.conf
@@ -18,3 +18,9 @@ kunden:$1:intern:**         @(\d{5})-doku-intern-l3        16
 users:j:$1:**               (j.*)                          16  # users beginning with J may delete
 users:j:$1:**               (.*)                           4   # other users may read
 
+# regex in namespaces
+reg:$1:(\d{3}):sub           @(\d{5})-doku-sub-r1          4
+reg:$1:sub-(\d{3}):sub       @(\d{5})-doku-bus-sub-r2      16
+reg:$1:sub-(\d{3}):*         @(\d{5})-doku-bus-sub-r2      2
+reg:$1:(sub-\d{2}):sub       @(\d{5})-doku-bus-sub-r3      8
+reg:$1:sub-(\d{2}):*         @(\d{5})-doku-bus-sub-r3      1

--- a/action.php
+++ b/action.php
@@ -295,7 +295,8 @@ class action_plugin_aclplusregex extends DokuWiki_Action_Plugin
     /**
      * Applies cleanID to each separate part of the ID
      *
-     * keeps * and ** placeholders
+     * Keeps * and ** placeholders, as well as parts containing
+     * regular expressions
      *
      * @param string $id
      * @return string
@@ -308,9 +309,24 @@ class action_plugin_aclplusregex extends DokuWiki_Action_Plugin
         for ($i = 0; $i < $count; $i++) {
             if ($parts[$i] == '**') continue;
             if ($parts[$i] == '*') continue;
+            if ($this->containsRegex($parts[$i])) continue;
+
             $parts[$i] = cleanID($parts[$i]);
             if ($parts[$i] === '') unset($parts[$i]);
         }
         return join(':', $parts);
+    }
+
+    /**
+     * Detect if a string contains a regular expression
+     * by the presence of parentheses
+     *
+     * @param $part
+     * @return bool
+     */
+    protected function containsRegex($part)
+    {
+        return strpos($part, '(') !== false &&
+            strpos($part, ')') !== false;
     }
 }

--- a/action.php
+++ b/action.php
@@ -281,9 +281,9 @@ class action_plugin_aclplusregex extends DokuWiki_Action_Plugin
                 if ($partA === '*') return 1;
                 if ($partB === '*') return -1;
 
-                // regex goes after what matches it
-                if ($this->containsRegex($partA) && preg_match("/$partA/", $partB)) return 1;
-                if ($this->containsRegex($partB) && preg_match("/$partB/", $partA)) return -1;
+                // regex goes after simple strings
+                if ($this->containsRegex($partA) && !$this->containsRegex($partB)) return 1;
+                if ($this->containsRegex($partB) && !$this->containsRegex($partA)) return -1;
 
                 // just compare alphabetically
                 return strcmp($a, $b);

--- a/action.php
+++ b/action.php
@@ -281,6 +281,10 @@ class action_plugin_aclplusregex extends DokuWiki_Action_Plugin
                 if ($partA === '*') return 1;
                 if ($partB === '*') return -1;
 
+                // regex goes after what matches it
+                if ($this->containsRegex($partA) && preg_match("/$partA/", $partB)) return 1;
+                if ($this->containsRegex($partB) && preg_match("/$partB/", $partA)) return -1;
+
                 // just compare alphabetically
                 return strcmp($a, $b);
             }


### PR DESCRIPTION
This PR handles additional regex in the ACL configuration of this plugin.

Now a line like this will be valid:
```
reg:$1:(\d{3}):sub           @(\d{5})-doku-sub-r1          4
```
It will still use the match from `(\d{5})` definition for the `$1` backreference, and **also** resolve the `(\d{3})` pattern in the id part. So the rule will apply to ids like `reg:00001:001:sub`.

Note: usually the id parts are cleaned up using `cleanId()`. Until now only the placeholders `*` and `**` were excluded from the cleanup. As of this PR any parts containing `(` and `)` are also considered special and treated as regex. Although using parentheses is not strictly required for matching, is seems like a safe rule of thumb for detecting regex.

I will update the documentation as soon as this is merged.